### PR TITLE
docs: correct spec naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ The goal of this project is to create a common library of generic web components
 
 All components in these repo extend from HTMLElement and dont use any libraries or framework.
 
-You can think of these components like using a native `<button>` element, you get all the functionality, and accessibility, keyboard nav, etc for free, you just have to style the button to your liking.
+You can think of these components like using a native `<button>` element, you get all the functionality, and accessibility, keyboard navigation, etc., for free, you just have to style the button to your liking.
 
 You can use these components to build an app, or compose them and build your own components with them.
 
 ## Usage
     
 ### Via npm
-Components can be installed via npm
+Components can be installed via npm:
 
 ```bash
 npm i --save @thepassle/generic-components
@@ -46,15 +46,15 @@ Alternatively you can load the components from a CDN and drop them in your HTML 
 
 | Component                                                     | Demo                                                                                  | Spec                                                                        | Status        |
 |---------------------------------------------------------------|---------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|---------------|
-| [generic-accordion](/generic-accordion/README.md)             | [demo](https://genericcomponents.netlify.app/generic-accordion/demo/index.html)       | [Wai Aria Practices](https://www.w3.org/TR/wai-aria-practices/#accordion)   | ✅            |        
-| [generic-alert](/generic-alert/README.md)                     | [demo](https://genericcomponents.netlify.app/generic-alert/demo/index.html)           | [Wai Aria Practices](https://www.w3.org/TR/wai-aria-practices/#alert)       | ✅            |               
-| [generic-dialog](/generic-dialog/README.md)                   | [demo](https://genericcomponents.netlify.app/generic-dialog/demo/index.html)          | [Wai Aria Practices](https://www.w3.org/TR/wai-aria-practices/#dialog_modal)| 🏗            |     
-| [generic-disclosure](/generic-disclosure/README.md)           | [demo](https://genericcomponents.netlify.app/generic-disclosure/demo/index.html)      | [Wai Aria Practices](https://www.w3.org/TR/wai-aria-practices/#disclosure)  | ✅            |      
-| [generic-listbox](/generic-listbox/README.md)                 | [demo](https://genericcomponents.netlify.app/generic-listbox/demo/index.html)         | [Wai Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/#radiobutton)     | ✅            |      
-| [generic-radio](/generic-radio/README.md)                 | [demo](https://genericcomponents.netlify.app/generic-radio/demo/index.html)         | [Wai Aria Practices](https://www.w3.org/TR/wai-aria-practices/#Listbox)     | ✅            |      
-| [generic-skiplink](/generic-skiplink/README.md)               | [demo](https://genericcomponents.netlify.app/generic-skiplink/demo/index.html)        | [Wai Aria Practices](https://webaim.org/techniques/skipnav/)                | ✅            |               
-| [generic-switch](/generic-switch/README.md)                   | [demo](https://genericcomponents.netlify.app/generic-switch/demo/index.html)          | [Wai Aria Practices](https://www.w3.org/TR/wai-aria-1.1/#switch)            | ✅            |        
-| [generic-tabs](/generic-tabs/README.md)                       | [demo](https://genericcomponents.netlify.app/generic-tabs/demo/index.html)            | [Wai Aria Practices](https://www.w3.org/TR/wai-aria-practices/#tabpanel)    | ✅            |        
+| [generic-accordion](/generic-accordion/README.md)             | [demo](https://genericcomponents.netlify.app/generic-accordion/demo/index.html)       | [WAI-ARIA Practices](https://www.w3.org/TR/wai-aria-practices/#accordion)   | ✅            |        
+| [generic-alert](/generic-alert/README.md)                     | [demo](https://genericcomponents.netlify.app/generic-alert/demo/index.html)           | [WAI-ARIA Practices](https://www.w3.org/TR/wai-aria-practices/#alert)       | ✅            |               
+| [generic-dialog](/generic-dialog/README.md)                   | [demo](https://genericcomponents.netlify.app/generic-dialog/demo/index.html)          | [WAI-ARIA Practices](https://www.w3.org/TR/wai-aria-practices/#dialog_modal)| 🏗            |     
+| [generic-disclosure](/generic-disclosure/README.md)           | [demo](https://genericcomponents.netlify.app/generic-disclosure/demo/index.html)      | [WAI-ARIA Practices](https://www.w3.org/TR/wai-aria-practices/#disclosure)  | ✅            |      
+| [generic-listbox](/generic-listbox/README.md)                 | [demo](https://genericcomponents.netlify.app/generic-listbox/demo/index.html)         | [WAI-ARIA Practices](https://www.w3.org/TR/wai-aria-practices-1.1/#radiobutton)     | ✅            |      
+| [generic-radio](/generic-radio/README.md)                 | [demo](https://genericcomponents.netlify.app/generic-radio/demo/index.html)         | [WAI-ARIA Practices](https://www.w3.org/TR/wai-aria-practices/#Listbox)     | ✅            |      
+| [generic-skiplink](/generic-skiplink/README.md)               | [demo](https://genericcomponents.netlify.app/generic-skiplink/demo/index.html)        | [WebAIM](https://webaim.org/techniques/skipnav/)                | ✅            |               
+| [generic-switch](/generic-switch/README.md)                   | [demo](https://genericcomponents.netlify.app/generic-switch/demo/index.html)          | [WAI-ARIA Practices](https://www.w3.org/TR/wai-aria-1.1/#switch)            | ✅            |        
+| [generic-tabs](/generic-tabs/README.md)                       | [demo](https://genericcomponents.netlify.app/generic-tabs/demo/index.html)            | [WAI-ARIA Practices](https://www.w3.org/TR/wai-aria-practices/#tabpanel)    | ✅            |        
 | [generic-visually-hidden](/generic-visually-hidden/README.md) | [demo](https://genericcomponents.netlify.app/generic-visually-hidden/demo/index.html) | [WebAIM](https://webaim.org/techniques/css/invisiblecontent/)               | ✅            |         
 
 


### PR DESCRIPTION
Notably, changes the spec name for `generic-skiplink` from "Wai aria" to "WebAIM".