### PR TITLE
Fixed example code for CDN embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import '@generic-components/components/switch.js';
 Alternatively you can load the components from a CDN and drop them in your HTML file as a script tag
 
 ```html
-<script src="https://unpkg.com/@generic-components/components@1.0.0/switch.js" type="module"></script>
+<script src="https://unpkg.com/@generic-components/components@latest/switch.js" type="module"></script>
 ```
 
 ```html


### PR DESCRIPTION
`https://unpkg.com/@generic-components/components@1.0.0/switch.js` returns the error "Cannot find package @generic-components/components@1.0.0". I changed it to `https://unpkg.com/@generic-components/components@latest/switch.js` and now it works.