### PR TITLE
Add headings-based tabs to generic-tabs

### DIFF
--- a/generic-tabs/GenericTabs.js
+++ b/generic-tabs/GenericTabs.js
@@ -76,7 +76,7 @@ export class GenericTabs extends SelectedMixin(BatchingElement) {
     if (!this.querySelector('[slot]')) {
       const unformattedEls = [...this.children];
       unformattedEls.forEach(node => {
-        if (['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(node.tagName.toLowerCase())) {
+        if (node instanceof HTMLHeadingElement) {
           const button = document.createElement('button');
           button.textContent = node.textContent;
           button.setAttribute('slot', 'tab');

--- a/generic-tabs/GenericTabs.js
+++ b/generic-tabs/GenericTabs.js
@@ -70,11 +70,29 @@ export class GenericTabs extends SelectedMixin(BatchingElement) {
 
   constructor() {
     super();
+
+    // Check if slots were setup
+    // If not, assume heading structure and preprocess light DOM
+    if (!this.querySelector('[slot]')) {
+      const unformattedEls = [...this.children];
+      unformattedEls.forEach(node => {
+        if (['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(node.tagName.toLowerCase())) {
+          const button = document.createElement('button');
+          button.textContent = node.textContent;
+          button.setAttribute('slot', 'tab');
+          node.parentNode.replaceChild(button, node);
+        } else {
+          node.setAttribute('slot', 'panel');
+        }
+      });
+    }
+
     this.attachShadow({ mode: 'open' });
     this.shadowRoot.appendChild(template.content.cloneNode(true));
   }
 
   update() {
+    // Preprocess markup for headings
     const { tabs, panels } = this.getElements();
     tabs.forEach((_, i) => {
       if (i === this.selected) {

--- a/generic-tabs/GenericTabs.js
+++ b/generic-tabs/GenericTabs.js
@@ -35,11 +35,19 @@ export class GenericTabs extends SelectedMixin(BatchingElement) {
     return {
       selectors: {
         tabs: {
-          selector: el => el.querySelectorAll("[slot='tab']"),
+          selector: el =>
+            Array.from(el.children).filter(node =>
+              node.matches('h1, h2, h3, h4, h5, h6, [slot="tab"]'),
+            ),
           focusTarget: true,
         },
         panels: {
-          selector: el => el.querySelectorAll("[slot='panel']"),
+          selector: el =>
+            Array.from(el.children).filter(
+              node =>
+                node.matches('h1 ~ *, h2 ~ *, h3 ~ *, h4 ~ *, h5 ~ *, h6 ~ *, [slot="panel"]') &&
+                !node.matches('h1, h2, h3, h4, h5, h6, [slot="tab"]'),
+            ),
         },
       },
       multiDirectional: true,
@@ -75,13 +83,13 @@ export class GenericTabs extends SelectedMixin(BatchingElement) {
   }
 
   update() {
-    this._preprocess();
     const { tabs, panels } = this.getElements();
     tabs.forEach((_, i) => {
+      tabs[i].slot = 'tab';
       if (i === this.selected) {
         tabs[i].setAttribute('selected', '');
         tabs[i].setAttribute('aria-selected', 'true');
-        tabs[i].removeAttribute('tabindex');
+        tabs[i].setAttribute('tabindex', '0');
         panels[i].removeAttribute('hidden');
         this.value = tabs[i].textContent.trim();
       } else {
@@ -100,23 +108,8 @@ export class GenericTabs extends SelectedMixin(BatchingElement) {
         panels[i].setAttribute('aria-labelledby', `generic-tab-${this.__uuid}-${i}`);
       }
     });
-  }
-
-  _preprocess() {
-    // Check if slots were setup in light DOM
-    // If not, assume heading structure and preprocess light DOM
-    if (!this.querySelector('[slot]')) {
-      const unformattedEls = [...this.children];
-      unformattedEls.forEach(node => {
-        if (node instanceof HTMLHeadingElement) {
-          const button = document.createElement('button');
-          button.textContent = node.textContent;
-          button.setAttribute('slot', 'tab');
-          node.parentNode.replaceChild(button, node);
-        } else {
-          node.setAttribute('slot', 'panel');
-        }
-      });
-    }
+    panels.forEach((_, i) => {
+      panels[i].slot = 'panel';
+    });
   }
 }

--- a/generic-tabs/GenericTabs.js
+++ b/generic-tabs/GenericTabs.js
@@ -70,29 +70,12 @@ export class GenericTabs extends SelectedMixin(BatchingElement) {
 
   constructor() {
     super();
-
-    // Check if slots were setup
-    // If not, assume heading structure and preprocess light DOM
-    if (!this.querySelector('[slot]')) {
-      const unformattedEls = [...this.children];
-      unformattedEls.forEach(node => {
-        if (node instanceof HTMLHeadingElement) {
-          const button = document.createElement('button');
-          button.textContent = node.textContent;
-          button.setAttribute('slot', 'tab');
-          node.parentNode.replaceChild(button, node);
-        } else {
-          node.setAttribute('slot', 'panel');
-        }
-      });
-    }
-
     this.attachShadow({ mode: 'open' });
     this.shadowRoot.appendChild(template.content.cloneNode(true));
   }
 
   update() {
-    // Preprocess markup for headings
+    this._preprocess();
     const { tabs, panels } = this.getElements();
     tabs.forEach((_, i) => {
       if (i === this.selected) {
@@ -117,5 +100,23 @@ export class GenericTabs extends SelectedMixin(BatchingElement) {
         panels[i].setAttribute('aria-labelledby', `generic-tab-${this.__uuid}-${i}`);
       }
     });
+  }
+
+  _preprocess() {
+    // Check if slots were setup in light DOM
+    // If not, assume heading structure and preprocess light DOM
+    if (!this.querySelector('[slot]')) {
+      const unformattedEls = [...this.children];
+      unformattedEls.forEach(node => {
+        if (node instanceof HTMLHeadingElement) {
+          const button = document.createElement('button');
+          button.textContent = node.textContent;
+          button.setAttribute('slot', 'tab');
+          node.parentNode.replaceChild(button, node);
+        } else {
+          node.setAttribute('slot', 'panel');
+        }
+      });
+    }
   }
 }

--- a/generic-tabs/demo/index.html
+++ b/generic-tabs/demo/index.html
@@ -341,7 +341,53 @@
           </div>
         </generic-tabs>
       </div>
-      <!--
+
+      <div class="demo">
+        <h3>Headings:</h3>
+        <hr />
+        <details>
+          <summary>Show code</summary>
+        <pre><code class="language-markup"><script type="prism-html-markup"><generic-tabs>
+  <h2>
+    About
+  </h2>
+  <div>
+    <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam
+      rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt
+      explicabo.</p>
+  </div>
+
+  <h2>
+    Contact
+  </h2>
+  <div>
+    <p>Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid
+      ex ea commodi consequatur.</p>
+  </div>
+</generic-tabs>
+  </script></code></pre>
+        </details>
+        <hr>
+        <generic-tabs>
+          <h2>
+            About
+          </h2>
+          <div>
+            <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam
+              rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt
+              explicabo.</p>
+          </div>
+
+          <h2>
+            Contact
+          </h2>
+          <div>
+            <p>Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid
+              ex ea commodi consequatur.</p>
+          </div>
+        </generic-tabs>
+      </div>
+        <!--
       <div id="foo"></div>
 
       <script type="module">

--- a/generic-tabs/test/generic-tabs.test.js
+++ b/generic-tabs/test/generic-tabs.test.js
@@ -413,10 +413,10 @@ describe('generic-tabs', () => {
     });
   });
 
-  describe('preprocessor', () => {
-    it('works with headings and no slots', async () => {
+  describe('headings', () => {
+    it('works with headings and no predefined slots', async () => {
       const el = await fixture(tabsWithHeadingsFixture);
-      const buttons = el.querySelectorAll('button');
+      const buttons = el.querySelectorAll('[slot="tab"]');
       buttons[1].click();
       await el.updateComplete;
       expect(buttons[1].getAttribute('aria-selected')).to.equal('true');
@@ -431,34 +431,6 @@ describe('generic-tabs', () => {
       expect(buttons[1].getAttribute('aria-selected')).to.equal('false');
       expect(buttons[1].hasAttribute('selected')).to.equal(false);
       expect(buttons[1].getAttribute('tabindex')).to.equal('-1');
-    });
-
-    it('works with DOM updates', async () => {
-      const el = await fixture(tabsWithHeadingsFixture);
-      let buttons = el.querySelectorAll('button');
-      expect(buttons.length).to.equal(2);
-      el.innerHTML = `
-        <h1>
-          Jim
-        </h1>
-        <div>
-          My name is Jim.
-        </div>
-        <h1>
-          Jack
-        </h1>
-        <div>
-          And I am Jack.
-        </div>
-        <h1>
-          John
-        </h1>
-        <div>
-          And I am John.
-        </div>
-      `;
-      buttons = el.querySelectorAll('button');
-      expect(buttons.length).to.equal(3);
     });
   });
 });

--- a/generic-tabs/test/generic-tabs.test.js
+++ b/generic-tabs/test/generic-tabs.test.js
@@ -20,6 +20,23 @@ const tabsFixture = html`
   </generic-tabs>
 `;
 
+const tabsWithHeadingsFixture = html`
+  <generic-tabs>
+    <h1>
+      Jim
+    </h1>
+    <div>
+      My name is Jim.
+    </div>
+    <h1>
+      Jack
+    </h1>
+    <div>
+      And I am Jack.
+    </div>
+  </generic-tabs>
+`;
+
 const tabsFixtureSelected = html`
   <generic-tabs selected="1">
     <button slot="tab">
@@ -393,6 +410,27 @@ describe('generic-tabs', () => {
       expect(buttons[0].getAttribute('aria-selected')).to.equal('false');
       expect(buttons[0].hasAttribute('selected')).to.equal(false);
       expect(buttons[0].getAttribute('tabindex')).to.equal('-1');
+    });
+  });
+
+  describe('headings', () => {
+    it('works with headings and no slots', async () => {
+      const el = await fixture(tabsWithHeadingsFixture);
+      const buttons = el.querySelectorAll('button');
+      buttons[1].click();
+      await el.updateComplete;
+      expect(buttons[1].getAttribute('aria-selected')).to.equal('true');
+      expect(buttons[1].hasAttribute('selected')).to.equal(true);
+      expect(buttons[0].getAttribute('aria-selected')).to.equal('false');
+      expect(buttons[0].hasAttribute('selected')).to.equal(false);
+      expect(buttons[0].getAttribute('tabindex')).to.equal('-1');
+      buttons[0].click();
+      await el.updateComplete;
+      expect(buttons[0].getAttribute('aria-selected')).to.equal('true');
+      expect(buttons[0].hasAttribute('selected')).to.equal(true);
+      expect(buttons[1].getAttribute('aria-selected')).to.equal('false');
+      expect(buttons[1].hasAttribute('selected')).to.equal(false);
+      expect(buttons[1].getAttribute('tabindex')).to.equal('-1');
     });
   });
 });

--- a/generic-tabs/test/generic-tabs.test.js
+++ b/generic-tabs/test/generic-tabs.test.js
@@ -457,7 +457,6 @@ describe('generic-tabs', () => {
           And I am John.
         </div>
       `;
-      console.log(el.innerHTML);
       buttons = el.querySelectorAll('button');
       expect(buttons.length).to.equal(3);
     });

--- a/generic-tabs/test/generic-tabs.test.js
+++ b/generic-tabs/test/generic-tabs.test.js
@@ -413,7 +413,7 @@ describe('generic-tabs', () => {
     });
   });
 
-  describe('headings', () => {
+  describe('preprocessor', () => {
     it('works with headings and no slots', async () => {
       const el = await fixture(tabsWithHeadingsFixture);
       const buttons = el.querySelectorAll('button');
@@ -431,6 +431,35 @@ describe('generic-tabs', () => {
       expect(buttons[1].getAttribute('aria-selected')).to.equal('false');
       expect(buttons[1].hasAttribute('selected')).to.equal(false);
       expect(buttons[1].getAttribute('tabindex')).to.equal('-1');
+    });
+
+    it('works with DOM updates', async () => {
+      const el = await fixture(tabsWithHeadingsFixture);
+      let buttons = el.querySelectorAll('button');
+      expect(buttons.length).to.equal(2);
+      el.innerHTML = `
+        <h1>
+          Jim
+        </h1>
+        <div>
+          My name is Jim.
+        </div>
+        <h1>
+          Jack
+        </h1>
+        <div>
+          And I am Jack.
+        </div>
+        <h1>
+          John
+        </h1>
+        <div>
+          And I am John.
+        </div>
+      `;
+      console.log(el.innerHTML);
+      buttons = el.querySelectorAll('button');
+      expect(buttons.length).to.equal(3);
     });
   });
 });


### PR DESCRIPTION
Per discussions over on #38, this attempts to add the heading+panel structure that auto-converts into tabs+panels. It's a very coarse pass, but I think it has the API we're aiming for.

```
<generic-tabs>
  <h#>Tab 1</h#>
  <div>Tab 1 panel content</div>  
  <h#>Tab 2</h#>
  <div>Tab 2 panel content</div>
</generic-tabs>
```

This is a non-breaking change and supports the existing `slot` API while layering in this new design.