### PR TITLE
Add default gap between tabs

### DIFF
--- a/generic-tabs/GenericTabs.js
+++ b/generic-tabs/GenericTabs.js
@@ -18,6 +18,7 @@ template.innerHTML = `
 
     div[role="tablist"] {
       display: flex;
+      gap: 0.5rem;
     }
   </style>
 


### PR DESCRIPTION
One issue we (@bkardell, @jonathantneal, and I) noticed with the default Tabs style was that the headings variant looked like CamelCase instead of two distinct tabs. This PR fixes that.

⚠️  This is probably a breaking change since it modifies the base element styles. Not sure how you want to approach that.